### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build container
         run: docker build .


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- replace 'set-output' command